### PR TITLE
Inconsistent spaces/tabs removed, some default values added to layread.py

### DIFF
--- a/inifile.py
+++ b/inifile.py
@@ -63,19 +63,19 @@ def ProcessIniLine(line):
    		- value:    value-string of a key, section, subsection, comment, or unknown string
    		- key:      key as string
    	"""
-   	status = 0
-   	key = '' # default; only return value possibly not set
-   	line = line.strip() # remove leading and trailing spaces
-   	endIdx = len(line)-1
-   	if not line: # empty sequence evaluates to false
-   		status = 0
-   		key = ''
-   		value = ''
-   		return (status,key,value)
-   	elif line[0]==';': # comment found
-   		status = 4
-   		value = line[1:endIdx+1]
-   	elif (line[0] == '[') and (line[endIdx] == ']') and (endIdx+1 >= 3): # section found
+	status = 0
+	key = '' # default; only return value possibly not set
+	line = line.strip() # remove leading and trailing spaces
+	endIdx = len(line)-1
+	if not line: # empty sequence evaluates to false
+		status = 0
+		key = ''
+		value = ''
+		return (status,key,value)
+	elif line[0]==';': # comment found
+		status = 4
+		value = line[1:endIdx+1]
+	elif (line[0] == '[') and (line[endIdx] == ']') and (endIdx+1 >= 3): # section found
 		status = 1
 		value = line[1:endIdx].lower()
 	elif (line[0] == '{') and (line[endIdx] == '}') and (endIdx+1 >= 3): # subsection found

--- a/layread.py
+++ b/layread.py
@@ -3,7 +3,7 @@ import numpy as np
 import pdb,traceback,sys
 import time
 
-def layread(layFileName,datFileName,timeOffset,timeLength):
+def layread(layFileName,datFileName,timeOffset=0,timeLength=-1):
 	"""
 	inputs:
 		layFileName - the .lay file name (or path)


### PR DESCRIPTION
Inconsistent spaces/tabs removed from infile.py. Default values added
to layread.py timeOffset and timeLength arguments. By default, layread
will import the entire file.
